### PR TITLE
Fix webpack production build

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -1,19 +1,17 @@
-/*eslint-disable*/
 const path = require('path');
 
 // Require some handy plugins
 const CleanWebpackPlugin = require('clean-webpack-plugin'); // Used to clean the dist folder on every build.
 const HtmlWebpackPlugin = require('html-webpack-plugin'); // Used to inject the correct script tags inside index.html
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');  // Used to bundle styles together.
+const MiniCssExtractPlugin = require('mini-css-extract-plugin'); // Used to bundle styles together.
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin'); // Can't beat that name! Used to optimize generated css for size.
 const TerserPlugin = require('terser-webpack-plugin'); // Used to optimize bundled javascript for size.
-const VueLoaderPlugin = require('vue-loader/lib/plugin') // This adds support for .vue files
+const VueLoaderPlugin = require('vue-loader/lib/plugin'); // This adds support for .vue files
 
 // Behold! The mighty Webpack config!
 module.exports = {
   entry: {
-    // Start looking for things to bundle/optimize from here. Webpack will look for require/import calls.
-    app: './src/app/index.js',
+    app: './src/app/index.js', // Start looking for things to bundle/optimize from here. Webpack will look for require/import calls.
   },
   output: {
     // Put bundled javascript inside the dist folder
@@ -22,8 +20,8 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'vue$': 'vue/dist/vue.runtime.common.js' // This will force a more lightweight version of Vue. Saving 20% on bundle size!
-    }
+      vue$: 'vue/dist/vue.runtime.common.js', // This will force a more lightweight version of Vue. Saving 20% on bundle size!
+    },
   },
   module: {
     // Rules define which files get a makeover by Webpack!
@@ -35,7 +33,7 @@ module.exports = {
       ],
     }, {
       test: /\.vue$/,
-      loader: 'vue-loader'
+      loader: 'vue-loader',
     }, {
       test: /\.scss$/,
       use: [
@@ -85,15 +83,9 @@ module.exports = {
     }),
     // Bundle css
     new MiniCssExtractPlugin({
-      filename: '[name].css',
+      filename: '[name].[contenthash].css',
       chunkFilename: '[id].css',
     }),
     new VueLoaderPlugin(),
   ],
-  // Dev server configuration.
-  devServer: {
-    contentBase: path.resolve(process.cwd(), 'dist/'),
-    compress: true,
-    port: 8080,
-  },
 };

--- a/config/webpack.development.js
+++ b/config/webpack.development.js
@@ -1,0 +1,15 @@
+const path = require('path');
+
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'eval-source-map', // This enables source maps for debugging purposes
+  devServer: {
+    contentBase: path.resolve(process.cwd(), 'dist/'),
+    compress: true,
+    open: true,
+    port: 8080,
+  },
+});

--- a/config/webpack.production.js
+++ b/config/webpack.production.js
@@ -1,0 +1,10 @@
+const merge = require('webpack-merge');
+
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'production',
+  output: {
+    filename: '[name].[contenthash].js',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "0.1.0",
   "description": "A cleaner redesign of the Deltion roster site",
   "scripts": {
-    "build": "webpack --mode=production",
-    "start": "webpack-dev-server --open --mode=development",
-    "dev": "webpack-dev-server --open --mode=development",
+    "build": "webpack --config=./config/webpack.production.js",
+    "dev": "webpack-dev-server --config=./config/webpack.development.js",
     "lint-js": "eslint \"src/app/**\"",
     "fix-js": "eslint \"src/app/**\" --fix",
     "lint-styles": "stylelint 'src/**/*.scss' --color --cache",
@@ -19,10 +18,10 @@
   "private": true,
   "devDependencies": {
     "babel-eslint": "10.0.1",
-    "eslint": "5.11.0",
+    "eslint": "5.12.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-vue": "5.0.0",
+    "eslint-plugin-vue": "5.1.0",
     "stylelint": "9.9.0"
   },
   "dependencies": {
@@ -30,7 +29,7 @@
     "@babel/polyfill": "7.2.5",
     "@babel/preset-env": "7.2.3",
     "axios": "0.18.0",
-    "babel-loader": "8.0.4",
+    "babel-loader": "8.0.5",
     "babel-runtime": "6.26.0",
     "clean-webpack-plugin": "1.0.0",
     "css-loader": "2.1.0",
@@ -41,13 +40,15 @@
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "postcss-loader": "3.0.0",
     "sass-loader": "7.1.0",
+    "terser-webpack-plugin": "1.2.1",
     "vue": "2.5.21",
-    "vue-loader": "15.4.2",
+    "vue-loader": "15.5.1",
     "vue-router": "3.0.2",
     "vue-template-compiler": "2.5.21",
     "vuex": "3.0.1",
     "webpack": "4.28.2",
-    "webpack-cli": "3.1.2",
-    "webpack-dev-server": "3.1.14"
+    "webpack-cli": "3.2.1",
+    "webpack-dev-server": "3.1.14",
+    "webpack-merge": "4.2.1"
   }
 }


### PR DESCRIPTION
This splits the webpack configuration into three files: `webpack.common.js`, `webpack.development.js` and `webpack.production.js`

This change is necessary to have webpack generate bundles with hashes in the file name:
![image](https://user-images.githubusercontent.com/13856515/50929341-4b56bb00-145d-11e9-9b38-422092886065.png)
These hashed bundle filenames are a common and efficient way to bust the browser cache.

As part of this PR the dependencies have also been updated.
